### PR TITLE
`FEAT` Implemented contains() method for linked list

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 12
+          distribution: adopt
 
       - name: Build and Test
         run: kotlin -classpath src tests.testdatastructures.TestLinkedListKt

--- a/src/main/kotlin/datastructures/LinkedList.kt
+++ b/src/main/kotlin/datastructures/LinkedList.kt
@@ -89,4 +89,18 @@ class LinkedList<T> {
 
         return null
     }
+
+    fun contains(item: T): Boolean {
+        var currentNode = head
+
+        while (currentNode != null) {
+            if (currentNode.item == item) {
+                return true
+            }
+
+            currentNode = currentNode.next
+        }
+
+        return false
+    }
 }

--- a/src/test/kotlin/testdatastructures/TestLinkedList.kt
+++ b/src/test/kotlin/testdatastructures/TestLinkedList.kt
@@ -103,4 +103,13 @@ class TestLinkedList {
         linkedList.addToTail(1)
         assertTrue(linkedList.size == 1)
     }
+
+    @Test
+    fun testContainsItemReturnsCorrectly() {
+        linkedList.addToTail(1)
+        linkedList.addToTail(2)
+
+        assertFalse(linkedList.contains(3))
+        assertTrue(linkedList.contains(2))
+    }
 }


### PR DESCRIPTION
Implemented `contains(item: T)` method to check if the linked list contains an instance of the item argument.
Tested the method, passing.